### PR TITLE
Fixes problem with multiple spaces or special chars in the dir name

### DIFF
--- a/lib/project-shell-env.coffee
+++ b/lib/project-shell-env.coffee
@@ -15,7 +15,7 @@ debug = ( statements... ) ->
 # @return [String]
 #
 shellEscape = ( string ) ->
-  return string.replace( /([^A-Za-z0-9_\-.,:\/@])/, "\\$1" )
+  return string.replace( /([^A-Za-z0-9_\-.,:\/@])/g, "\\$1" )
 
 ##
 # Returns shell environment variables in the given directory as string.


### PR DESCRIPTION
Uses /g regexp option to replace all occurances of not accepted chars.
