### PR TITLE
Fix problems with complex PS1

### DIFF
--- a/lib/project-shell-env.coffee
+++ b/lib/project-shell-env.coffee
@@ -44,7 +44,7 @@ getShellEnv = ( path, timeout = 1000 ) ->
     "cd #{shellEscape path} || exit -1",
 
     # Print env inside markers
-    "echo '#{marker}' && env && echo '#{marker}'",
+    "PS1='$ '; echo '#{marker}' && env && echo '#{marker}'",
 
     # Exit shell
     "exit"


### PR DESCRIPTION
Such as multiline PS1 with color.

My PS1 looks like this (powerline-shell) - it throws an error on parsing of the environment as the second line is not valid.

![Bildschirmfoto von 2019-05-16 13-33-40](https://user-images.githubusercontent.com/121874/57850875-5b9dee80-77df-11e9-9c60-865962b86cbf.png)

Resetting PS1 to a bare value helps.

Thanks for your package! :green_heart: 